### PR TITLE
Provide seams for asset configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,22 @@ And for `Showcase::PagesController#show` we render:
 If you want to override any specific rendering, e.g. how a `Showcase::Page` is rendered,
 copy the file from our repo `app/views` directory into your `app/views` directory.
 
+### Loading your own assets
+
+Showcase bundles its own `showcase.js` and `showcase.css` asset files through
+Action View's [javascript_include_tag][] and [stylesheet_link_tag][].
+
+If your assets require more sophisticated loading techniques, declare your own
+versions of the [showcase/engine/_javascripts.html.erb][] and
+[showcase/engine/_stylesheets.html.erb][] partials. When customizing those
+partials, make sure to include `"showcase"` in your list of assets.
+
+
+[javascript_include_tag]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-javascript_include_tag
+[stylesheet_link_tag]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-stylesheet_link_tag
+[showcase/engine/_javascripts.html.erb]: ./showcase/engine/_javascripts.html.erb
+[showcase/engine/_stylesheets.html.erb]: ./showcase/engine/_stylesheets.html.erb
+
 ## Installation
 
 Add this line to your application's Gemfile:

--- a/app/views/layouts/showcase.html.erb
+++ b/app/views/layouts/showcase.html.erb
@@ -4,8 +4,8 @@
     <title>Showcase</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
 
-    <%= stylesheet_link_tag    "application", "showcase" %>
-    <%= javascript_include_tag "application", "showcase" %>
+    <%= render "stylesheets" %>
+    <%= render "javascripts" %>
   </head>
 
   <body>

--- a/app/views/showcase/engine/_javascripts.html.erb
+++ b/app/views/showcase/engine/_javascripts.html.erb
@@ -1,0 +1,1 @@
+<%= javascript_include_tag "application", "showcase" %>

--- a/app/views/showcase/engine/_stylesheets.html.erb
+++ b/app/views/showcase/engine/_stylesheets.html.erb
@@ -1,0 +1,1 @@
+<%= stylesheet_link_tag "application", "showcase" %>


### PR DESCRIPTION
Introduce the `showcase/engine/javascripts` and
`showcase/engine/stylesheets` partials (named after the `Showcase::EngineController` view path) so that consumer applications can extend them.

For example, if a host application utilizes Importmaps for their JavaScript assets, they'll need to include their own [javascript_importmap_tags][] in addition to including `javascript_include_tag "showcase"` (note the _absence_ of `"application"` in the argument list).

[javascript_importmap_tags]: https://github.com/rails/importmap-rails/tree/v1.1.5#usage