### PR TITLE
Add HTML Test Coverage

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,3 +21,11 @@ gem "sprockets-rails"
 # gem "debug", ">= 1.0.0"
 
 gem "puma", "~> 5.6"
+
+group :test do
+  gem "action_dispatch-testing-integration-capybara",
+    github: "thoughtbot/action_dispatch-testing-integration-capybara", tag: "v0.1.1",
+    require: "action_dispatch/testing/integration/capybara/minitest"
+  gem "capybara_accessible_selectors",
+    github: "citizensadvice/capybara_accessible_selectors", tag: "v0.10.0"
+end

--- a/app/views/showcase/_root.html.erb
+++ b/app/views/showcase/_root.html.erb
@@ -1,7 +1,7 @@
-<main class="sc-flex sc-flex-wrap">
+<main class="sc-flex sc-flex-wrap" aria-labelledby="showcase_main_title">
   <section class="sc-grid sc-grid-cols-12 sc-w-full">
     <nav class="sc-col-span-3 xl:sc-col-span-2 sc-py-5 sc-h-full sc-border-r">
-      <h1 class="sc-font-black sc-text-2xl sc-py-2 sc-pl-4 sc-cursor-pointer"><%= link_to "Showcase", root_url %></h1>
+      <h1 id="showcase_main_title" class="sc-font-black sc-text-2xl sc-py-2 sc-pl-4 sc-cursor-pointer"><%= link_to "Showcase", root_url %></h1>
 
       <%= render Showcase::Path.tree %>
     </nav>

--- a/app/views/showcase/pages/_options.html.erb
+++ b/app/views/showcase/pages/_options.html.erb
@@ -15,7 +15,14 @@
         <tr class="sc-border-t sc-border-gray-200">
           <% option.each do |key, value| %>
             <% if key == :required %>
-              <td class="sc-p-4"><%= tag.input type: :checkbox, checked: value, disabled: true if value %></td>
+              <td class="sc-p-4">
+                <% if value %>
+                  <%= tag.label do %>
+                    <span class="sc-sr-only">true</span>
+                    <%= tag.input type: :checkbox, checked: value, readonly: true %>
+                  <% end %>
+                <% end %>
+              </td>
             <% else %>
               <td class="sc-p-4"><%= tag.pre value %></td>
             <% end %>

--- a/app/views/showcase/pages/_sample.html.erb
+++ b/app/views/showcase/pages/_sample.html.erb
@@ -1,7 +1,7 @@
-<section class="sc-mb-4 sc-border sc-border-gray-200 sc-rounded-md">
+<section class="sc-mb-4 sc-border sc-border-gray-200 sc-rounded-md" aria-labelledby="showcase_<%= sample.id %>_title">
   <showcase-sample id="<%= sample.id %>" events="<%= sample.events %>">
     <header class="sc-bg-slate-100/50">
-      <h3 class="sc-px-4 sc-py-2 sc-font-medium sc-text-base md:sc-text-lg sc-leading-snug sc-truncate"><%= link_to sample.name, "##{sample.id}" %></h3>
+      <h3 id="showcase_<%= sample.id %>_title" class="sc-px-4 sc-py-2 sc-font-medium sc-text-base md:sc-text-lg sc-leading-snug sc-truncate"><%= link_to sample.name, "##{sample.id}" %></h3>
 
       <% if sample.description %>
         <p class="sc-px-4 sc-py-2 sc-text-base"><%= sample.description %></p>
@@ -25,8 +25,8 @@
     <% end %>
 
     <% if sample.events.any? %>
-      <section class="sc-px-4 sc-py-2 sc-font-small sc-bg-slate-50">
-        <h4 class="sc-mb-2 sc-font-medium sc-text-base">JavaScript Events</h4>
+      <section class="sc-px-4 sc-py-2 sc-font-small sc-bg-slate-50" aria-labelledby="showcase_<%= sample.id %>_javascript_events_title">
+        <h4 id="showcase_<%= sample.id %>_javascript_events_title" class="sc-mb-2 sc-font-medium sc-text-base">JavaScript Events</h4>
 
         <div class="sc-overflow-scroll sc-max-h-20">
           <pre data-showcase-sample-target="relay"></pre>

--- a/app/views/showcase/pages/index.html.erb
+++ b/app/views/showcase/pages/index.html.erb
@@ -1,5 +1,5 @@
-<article class="sc-space-y-4 sc-font-normal sc-text-base">
-  <p class="sc-font-normal sc-text-xl">👋  Welcome to <span class="sc-italic">Showcase</span> — your UI Pattern Library!</p>
+<article class="sc-space-y-4 sc-font-normal sc-text-base" aria-labelledby="showcase_article_title">
+  <p id="showcase_article_title" class="sc-font-normal sc-text-xl">👋  Welcome to <span class="sc-italic">Showcase</span> — your UI Pattern Library!</p>
 
   <section class="sc-space-y-4">
     <h2 class="sc-font-semibold sc-text-2xl">What is this thing?</h2>

--- a/test/capybara_extensions.rb
+++ b/test/capybara_extensions.rb
@@ -1,0 +1,5 @@
+module CapybaraExtensions
+end
+
+require "capybara_extensions/assertions"
+require "capybara_extensions/filters/data"

--- a/test/capybara_extensions/assertions.rb
+++ b/test/capybara_extensions/assertions.rb
@@ -1,0 +1,28 @@
+module CapybaraExtensions::Assertions
+  %i[element disclosure link region section table_row].each do |selector|
+    class_eval <<~RUBY, __FILE__, __LINE__ + 1
+      def assert_#{selector}(...)
+        assert_selector(#{selector.inspect}, ...)
+      end
+
+      def assert_no_#{selector}(...)
+        assert_no_selector(#{selector.inspect}, ...)
+      end
+    RUBY
+  end
+end
+
+Capybara::Node::Matchers.include CapybaraExtensions::Assertions
+
+ActiveSupport.on_load :action_dispatch_integration_test do
+  include CapybaraExtensions::Assertions
+end
+
+ActiveSupport.on_load :action_view_test_case do
+  include Capybara::Minitest::Assertions
+  include CapybaraExtensions::Assertions
+
+  def page
+    @page ||= Capybara.string(rendered)
+  end
+end

--- a/test/capybara_extensions/filters/data.rb
+++ b/test/capybara_extensions/filters/data.rb
@@ -1,0 +1,42 @@
+Capybara::Selector.all.each_key do |selector|
+  Capybara.modify_selector selector do
+    # Accept a `data: {...}` filter that transforms nested keys in the same
+    # style as Action View's `tag` builder:
+    #
+    #   https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/TagHelper.html#method-i-tag-label-Options
+    #
+    # Values are passed straight through to Capybara, and transformed
+    # to XPath queries
+    #
+    #  # this assertion fails for
+    #  # => <button data-controller="element another-controller"></button>
+    #  assert_button "Hello", data: {controller: "element"}
+    #
+    #  # this assertion passes for
+    #  # => <button data-controller="element another-controller"></button>
+    #  assert_button "Hello", data: {controller: /element/}
+    #
+    expression_filter(:data, Hash, skip_if: nil) do |scope, nested_attributes|
+      prefixed_attributes = nested_attributes.transform_keys { |key| "data-#{key.to_s.dasherize}" }
+
+      case scope
+      when String
+        selectors = prefixed_attributes.map { |key, value| %([#{key}="#{value}"]) }
+
+        [scope, *selectors].join
+      else
+        expressions = prefixed_attributes.map do |key, value|
+          builder(XPath.self).add_attribute_conditions(key.to_sym => value)
+        end
+
+        scope[expressions.reduce(:&)]
+      end
+    end
+
+    describe(:expression_filters) do |data: {}, **|
+      attributes = data.map { |key, value| %(data-#{key.to_s.dasherize}="#{value}") }
+
+      " with #{attributes.join(" and ")}" unless attributes.empty?
+    end
+  end
+end

--- a/test/controllers/showcase/pages_controller_test.rb
+++ b/test/controllers/showcase/pages_controller_test.rb
@@ -1,42 +1,96 @@
 require "test_helper"
 
 class Showcase::PagesControllerTest < Showcase::IntegrationTest
-  test "should get index" do
-    get root_url
+  test "#index renders Welcome content" do
+    get showcase_path
 
-    assert_response :success
-    assert_select "details summary", "Templates"
-    assert_select %(details a[href="/docs/showcase/pages/button"]),   "Button"
-    assert_select %(details a[href="/docs/showcase/pages/combobox"]), "Combobox"
-
-    assert_select "details summary", "Stimulus Controllers"
-    assert_select %(details a[href="/docs/showcase/pages/stimulus_controllers/welcome"]), "Welcome"
+    assert_response :ok
+    assert_title "Showcase"
+    within :main, "Showcase" do
+      within :article, "Welcome to Showcase — your UI Pattern Library" do
+        assert_section "What is this thing?"
+        assert_section "How do I use it?"
+        assert_section "But I don't see the thing I need"
+        assert_section "I have questions, who do I reach out to?"
+        assert_section "Additional resources"
+      end
+    end
   end
 
-  test "should get show" do
-    get page_url("button")
+  test "#index renders navigation" do
+    get showcase_path
 
-    assert_response :success
-    assert_select %(button[class~="text-xs"]), text: "Button content"
-    assert_select %(button[class~="text-xl"]), text: "Button content"
+    assert_response :ok
+    within :navigation do
+      assert_link "Showcase", href: root_url
 
-    assert_select "table tr td pre", text: "The content to output as the button text"
-    assert_select "table tr td pre", text: "content"
+      within :disclosure, "Templates", expanded: true do
+        assert_link "Button", href: page_path("button")
+        assert_link "Combobox", href: page_path("combobox")
+      end
+      within :disclosure, "Stimulus Controllers", expanded: true do
+        assert_link "Welcome", href: page_path("stimulus_controllers/welcome")
+      end
+    end
   end
 
-  test "get nested component" do
-    get page_url("combobox")
+  test "#show renders samples and options" do
+    get page_path("button")
 
-    assert_response :success
-    assert_select "table", count: 0
+    assert_response :ok
+    within :section, "Samples" do
+      assert_button "Button content", class: %w[text-xs]
+      assert_button "Button content", class: %w[text-xl]
+    end
+
+    within :section, "Options" do
+      assert_table with_rows: [
+        {"Name" => "content", "Required" => "true", "Type" => "String", "Default" => "", "Description" => "The content to output as the button text", "Options" => ""},
+        {"Name" => "mode", "Required" => "", "Type" => "Symbol", "Default" => ":small", "Description" => "We support three modes", "Options" => "[:small, :medium, :large]"}
+      ]
+    end
   end
 
-  test "rendering stimulus controller" do
-    get page_url("stimulus_controllers/welcome")
+  test "#show does not render a <table>" do
+    get page_path("combobox")
 
-    assert_response :success
-    assert_select %(div[data-controller="welcome"]), count: 3
-    assert_select %(div[data-controller="welcome"][data-welcome-yell-value])
-    assert_select %(div[data-controller="welcome"] div[data-welcome-target="greeter"])
+    assert_response :ok
+    assert_no_section "Options"
+    assert_no_table
+  end
+
+  test "#show renders a title and description" do
+    get page_path("stimulus_controllers/welcome")
+
+    assert_response :ok
+    assert_section "Welcome", text: "The welcome controller says hello when it enters the screen"
+  end
+
+  test "#show renders samples" do
+    get page_path("stimulus_controllers/welcome")
+
+    within :section, "Samples" do
+      assert_region "Basic", text: "I've just said welcome!"
+      within :region, "With greeter" do
+        within :element, data: {controller: "welcome"} do
+          assert_element text: "Somebody", data: {welcome_target: "greeter"}
+        end
+      end
+
+      within :region, "Yelling!!!" do
+        assert_element data: {controller: "welcome", welcome_yell_value: "true"}
+      end
+    end
+  end
+
+  test "#show renders options" do
+    get page_path("stimulus_controllers/welcome")
+
+    within :section, "Options" do
+      assert_table with_rows: [
+        {"Name" => "data-welcome-target", "Required" => "", "Type" => "String", "Default" => "", "Description" => "If the id of the target element must be printed"},
+        {"Name" => "data-welcome-yell-value", "Required" => "", "Type" => "Boolean", "Default" => "false", "Description" => "Whether the hello is to be YELLED"}
+      ]
+    end
   end
 end

--- a/test/integration/navigation_test.rb
+++ b/test/integration/navigation_test.rb
@@ -1,7 +1,0 @@
-require "test_helper"
-
-class NavigationTest < ActionDispatch::IntegrationTest
-  # test "the truth" do
-  #   assert true
-  # end
-end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -4,6 +4,7 @@ ENV["RAILS_ENV"] = "test"
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"
+require "capybara_extensions"
 
 # Load fixtures from the engine
 if ActiveSupport::TestCase.respond_to?(:fixture_path=)

--- a/test/views/showcase/pages/_sample.html.erb_test.rb
+++ b/test/views/showcase/pages/_sample.html.erb_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+module Showcase::Pages
+  class SamplePartialTest < ActionView::TestCase
+    test "showcase/pages/sample renders its name and description" do
+      sample = showcase_sample "A sample" do |partial|
+        partial.description { "A description" }
+      end
+
+      render "showcase/pages/sample", sample: sample
+
+      assert_region "A sample" do |section|
+        section.assert_element "showcase-sample" do |showcase_sample|
+          showcase_sample.assert_link "A sample", href: "#a-sample"
+          showcase_sample.assert_text "A description"
+        end
+      end
+    end
+
+    test "showcase/pages/sample renders a preview and its source" do
+      sample = showcase_sample { "<pre>ERB</pre>" }
+
+      render "showcase/pages/sample", sample: sample
+
+      assert_element "showcase-sample" do |showcase_sample|
+        showcase_sample.assert_text "ERB"
+        showcase_sample.assert_disclosure "View Source", expanded: false
+      end
+    end
+
+    test "showcase/pages/sample renders a region to capture JavaScript events" do
+      sample = showcase_sample("with events", events: "click") { "<pre>ERB</pre>" }
+
+      render "showcase/pages/sample", sample: sample
+
+      assert_element "showcase-sample", events: ["click"] do |showcase_sample|
+        showcase_sample.assert_region "JavaScript Events" do |section|
+          section.assert_element data: {showcase_sample_target: "relay"}
+        end
+      end
+    end
+
+    def showcase_sample(name = "sample name", ...)
+      page = Showcase::Page.new(view, id: "showcase_test")
+
+      page.sample(name, ...).first
+    end
+  end
+end


### PR DESCRIPTION
Add HTML-level test coverage at both the Integration Test and View Partial test layers.

To improve that coverage, depend on [capybara_accessible_selectors][] and [action_dispatch-testing-integration-capybara][] to provide access to Capybara's HTML parsing and semantic assertions.

In some cases, the [capybara_accessible_selectors][]-powered semantic assertions uncovered some inaccessible regions, so this commit also ensures that `<section>` element are labelled by corresponding `<h#>` elements.

[capybara_accessible_selectors]: https://github.com/citizensadvice/capybara_accessible_selectors/tree/v0.10.0
[action_dispatch-testing-integration-capybara]: https://github.com/thoughtbot/action_dispatch-testing-integration-capybara/tree/v0.1.1