### PR TITLE
Fail CI when Tailwind generates a diff

### DIFF
--- a/app/assets/builds/showcase.css
+++ b/app/assets/builds/showcase.css
@@ -679,18 +679,6 @@ select {
   --tw-backdrop-sepia:  ;
 }
 
-.sc-sr-only {
-  position: absolute;
-  width: 1px;
-  height: 1px;
-  padding: 0;
-  margin: -1px;
-  overflow: hidden;
-  clip: rect(0, 0, 0, 0);
-  white-space: nowrap;
-  border-width: 0;
-}
-
 .sc-relative {
   position: relative;
 }

--- a/app/views/showcase/pages/_options.html.erb
+++ b/app/views/showcase/pages/_options.html.erb
@@ -16,12 +16,7 @@
           <% option.each do |key, value| %>
             <% if key == :required %>
               <td class="sc-p-4">
-                <% if value %>
-                  <%= tag.label do %>
-                    <span class="sc-sr-only">true</span>
-                    <%= tag.input type: :checkbox, checked: value, readonly: true %>
-                  <% end %>
-                <% end %>
+                <%= tag.input type: :checkbox, checked: value, disabled: true if value%>
               </td>
             <% else %>
               <td class="sc-p-4"><%= tag.pre value %></td>

--- a/test/controllers/showcase/pages_controller_test.rb
+++ b/test/controllers/showcase/pages_controller_test.rb
@@ -45,7 +45,7 @@ class Showcase::PagesControllerTest < Showcase::IntegrationTest
 
     within :section, "Options" do
       assert_table with_rows: [
-        {"Name" => "content", "Required" => "true", "Type" => "String", "Default" => "", "Description" => "The content to output as the button text", "Options" => ""},
+        {"Name" => "content", "Required" => "", "Type" => "String", "Default" => "", "Description" => "The content to output as the button text", "Options" => ""},
         {"Name" => "mode", "Required" => "", "Type" => "Symbol", "Default" => ":small", "Description" => "We support three modes", "Options" => "[:small, :medium, :large]"}
       ]
     end


### PR DESCRIPTION
Execute `bin/tailwindcss` in CI. If it modifies any styles, fail the build.