### PR TITLE
Test Coverage for template- and partial-overrides

### DIFF
--- a/test/controllers/showcase/engine_controller_test.rb
+++ b/test/controllers/showcase/engine_controller_test.rb
@@ -33,4 +33,19 @@ class Showcase::EngineControllerTest < Showcase::IntegrationTest
       end
     end
   end
+
+  test "#index template can be overridden" do
+    template_file "showcase/engine/index.html.erb", <<~HTML
+      <section aria-labelledby="title">
+        <h2 id="title">A Custom Welcome</h2>
+      </section>
+    HTML
+
+    get showcase_path
+
+    assert_response :ok
+    within :main, "Showcase" do
+      assert_region "A Custom Welcome"
+    end
+  end
 end

--- a/test/controllers/showcase/pages_controller_test.rb
+++ b/test/controllers/showcase/pages_controller_test.rb
@@ -50,6 +50,41 @@ class Showcase::PagesControllerTest < Showcase::IntegrationTest
     end
   end
 
+  test "#show reads samples from partials in app/views/showcase/samples/" do
+    name = SecureRandom.uuid
+
+    template_file "showcase/samples/_test_local_sample.html.erb", <<~HTML
+      <% showcase.sample "#{name}" do %>
+        A new sample: #{name}
+      <% end %>
+    HTML
+
+    get page_path("test_local_sample")
+
+    within :navigation do
+      assert_link "Test Local Sample", href: page_path("test_local_sample")
+    end
+    within :section, "Samples" do
+      assert_region name, text: "A new sample: #{name}"
+    end
+  end
+
+  test "#show renders Custom sample partials" do
+    template_file "showcase/pages/_sample.html.erb", <<~HTML
+      <turbo-frame id="<%= sample.id %>_frame">
+        <%= sample.name %>
+      </turbo-frame>
+    HTML
+
+    get page_path("stimulus_controllers/welcome")
+
+    within :section, "Samples" do
+      assert_element "turbo-frame", text: "Basic"
+      assert_element "turbo-frame", text: "With greeter"
+      assert_element "turbo-frame", text: "Yelling!!!"
+    end
+  end
+
   test "#show renders options" do
     get page_path("stimulus_controllers/welcome")
 

--- a/test/template_helpers.rb
+++ b/test/template_helpers.rb
@@ -1,0 +1,22 @@
+module TemplateHelpers
+  def setup
+    super
+    @temporary_view_path = Pathname.new(Dir.mktmpdir).join("app", "views")
+    @view_paths = ActionController::Base.view_paths
+
+    ActionController::Base.prepend_view_path(@temporary_view_path)
+  end
+
+  def teardown
+    super
+    ActionController::Base.view_paths = @view_paths
+  end
+
+  def template_file(partial, html)
+    @temporary_view_path.join(partial).tap do |file|
+      file.dirname.mkpath
+
+      file.write(html)
+    end
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -5,6 +5,7 @@ require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
 require "rails/test_help"
 require "capybara_extensions"
+require "template_helpers"
 
 # Load fixtures from the engine
 if ActiveSupport::TestCase.respond_to?(:fixture_path=)
@@ -12,6 +13,10 @@ if ActiveSupport::TestCase.respond_to?(:fixture_path=)
   ActionDispatch::IntegrationTest.fixture_path = ActiveSupport::TestCase.fixture_path
   ActiveSupport::TestCase.file_fixture_path = ActiveSupport::TestCase.fixture_path + "/files"
   ActiveSupport::TestCase.fixtures :all
+end
+
+class ActiveSupport::TestCase
+  include TemplateHelpers
 end
 
 class Showcase::IntegrationTest < ActionDispatch::IntegrationTest


### PR DESCRIPTION
Introduce the `TemplateHelpers` test module to support ad-hoc ERB templates.

With that available, this commit adds coverage for:

* overriding `showcase/engines/index.html.erb`
* overriding `showcase/pages/_sample.html.erb`
* defining `showcase/samples/_test_sample.html.erb`