### PR TITLE
Support partials with host application routes

### DIFF
--- a/app/controllers/showcase/engine_controller.rb
+++ b/app/controllers/showcase/engine_controller.rb
@@ -1,5 +1,9 @@
+require "showcase/route_helper"
+
 class Showcase::EngineController < ActionController::Base
   layout "showcase"
+
+  helper Showcase::RouteHelper
 
   if defined?(::ApplicationController)
     helper all_helpers_from_path ::ApplicationController.helpers_path

--- a/lib/showcase/route_helper.rb
+++ b/lib/showcase/route_helper.rb
@@ -1,0 +1,8 @@
+module Showcase::RouteHelper
+  def method_missing(name, ...)
+    case name
+    when /_path\Z/, /_url\Z/ then main_app.public_send(name, ...)
+    else                          super
+    end
+  end
+end

--- a/test/controllers/showcase/pages_controller_test.rb
+++ b/test/controllers/showcase/pages_controller_test.rb
@@ -69,6 +69,18 @@ class Showcase::PagesControllerTest < Showcase::InternalIntegrationTest
     end
   end
 
+  test "#show samples can access URL helpers for the main_app" do
+    template_file "showcase/samples/_link.html.erb", <<~HTML
+      <% showcase.sample "root" do %>
+        <%= link_to "root", main_app_root_path %>
+      <% end %>
+    HTML
+
+    get page_path("link")
+
+    assert_link "root", href: "/main_app_root"
+  end
+
   test "#show renders Custom sample partials" do
     template_file "showcase/pages/_sample.html.erb", <<~HTML
       <turbo-frame id="<%= sample.id %>_frame">

--- a/test/dummy/config/routes.rb
+++ b/test/dummy/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  get "/main_app_root" => redirect("/"), as: :main_app_root
+
   root to: redirect("/docs/showcase")
 
   mount Showcase::Engine, at: "docs/showcase"


### PR DESCRIPTION
It's possible for the host application's sample block to render an Action View partial that links to a Real Path.

It wouldn't be reasonable to expect the implementation-side view partials to prefix their routes with `main_app` to differentiate between themselves and the engine.

This commit declares a `Showcase::RoutingHelper` to expand the set of routes available to templates rendered by `Showcase::EngineController` (including `Showcase::PagesController`).

[main_app]: https://guides.rubyonrails.org/engines.html#routes