### PR TITLE
Load with Zeitwerk

### DIFF
--- a/lib/showcase.rb
+++ b/lib/showcase.rb
@@ -17,4 +17,4 @@ module Showcase
   end
 end
 
-require "showcase/engine" if defined?(Rails)
+require "showcase/engine" if defined?(Rails::Engine)


### PR DESCRIPTION
Set up a `Zeitwerk::Loader` by calling [for_gem][], ignoring the atypically named `showcase-rails` file.

With the acknowledgement of our transitive `zeitwerk` dependency, we can omit any `require` or `autoload` calls.

[for_gem]: https://github.com/fxn/zeitwerk#for_gem