### PR TITLE
Route Engine root path to `showcase/engines#index`

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ The actions all use a `layout "showcase"`, which renders like this:
 
 So for `Showcase::EngineController#index` we render:
 
-- [showcase/engines/index.html.erb](app/views/showcase/engines/index.html.erb)
+- [showcase/engine/index.html.erb](app/views/showcase/engine/index.html.erb)
 
 And for `Showcase::PagesController#show` we render:
 

--- a/app/controllers/showcase/engine_controller.rb
+++ b/app/controllers/showcase/engine_controller.rb
@@ -1,5 +1,3 @@
-require "showcase/route_helper"
-
 class Showcase::EngineController < ActionController::Base
   layout "showcase"
 
@@ -7,5 +5,8 @@ class Showcase::EngineController < ActionController::Base
 
   if defined?(::ApplicationController)
     helper all_helpers_from_path ::ApplicationController.helpers_path
+  end
+
+  def index
   end
 end

--- a/app/controllers/showcase/pages_controller.rb
+++ b/app/controllers/showcase/pages_controller.rb
@@ -1,7 +1,4 @@
 class Showcase::PagesController < Showcase::EngineController
-  def index
-  end
-
   def show
     @page = Showcase::Path.new(params[:id]).page_for view_context
   end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,4 @@
 Showcase::Engine.routes.draw do
   get "pages/*id", to: "pages#show", as: :page
-  root to: "pages#index"
+  root to: "engine#index"
 end


### PR DESCRIPTION
Instead of relying on controller inheritance to implicitly render the `engines#index` route, this commit _explicitly_ routes the root path to `engines#index`.