### PR TITLE
Ensure test support for deeply nested previews

### DIFF
--- a/app/models/showcase/path.rb
+++ b/app/models/showcase/path.rb
@@ -21,7 +21,7 @@ class Showcase::Path
     end
 
     def ordered_paths
-      children.reject { _1.is_a?(Tree) }.flatten
+      children.flat_map { _1.is_a?(Tree) ? _1.ordered_paths : _1 }
     end
 
     def self.index(...)

--- a/test/integration/showcase_test.rb
+++ b/test/integration/showcase_test.rb
@@ -9,6 +9,10 @@ class ShowcaseTest < Showcase::IntegrationTest
     refute_empty self.class.runnable_methods.grep(/\Atest_Showcase/)
   end
 
+  test "defines tests for deeply nested previews" do
+    refute_empty self.class.runnable_methods.grep(%r{GET_showcase/previews/deeply/nested/partial})
+  end
+
   def assert_showcase_preview(path)
   end
 end


### PR DESCRIPTION
Prior to this commit, deeply nested previews were omitted from the reflectively defined list of `ActionDispatch::IntegrationTest` test cases.

This commit changes `Tree#ordered_paths` to exhaustively walk its tree in search of leaf node descendants.