### PR TITLE
Yank Zeitwerk for now

### DIFF
--- a/lib/showcase.rb
+++ b/lib/showcase.rb
@@ -1,9 +1,9 @@
-require "zeitwerk"
-loader = Zeitwerk::Loader.for_gem
-loader.ignore("#{__dir__}/showcase-rails.rb")
-loader.setup
+require_relative "showcase/version"
 
 module Showcase
+  autoload :IntegrationTest, "showcase/integration_test"
+  autoload :RouteHelper,     "showcase/route_helper"
+
   singleton_class.attr_accessor :sample_renderer
   @sample_renderer = ->(lines) { tag.pre lines.join.strip_heredoc }
 


### PR DESCRIPTION
Having a `Zeitwerk::Loader.for_gem` seems to not collaborate with `Rails.autoloaders`, so `"Showcase::EngineController".constantize` somehow won't be able to autoload the controller.

I can't figure out what's going on, so let's manually autoload for now.