### PR TITLE
Fix rename integration test installer

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Which will then render the following:
 
 ![](/readme/example.png?raw=true "Showcase showing a button component")
 
-## Automatic smokescreen testing
+## Automatic integration testing
 
 Showcase automatically runs integration tests for all your Showcases by rendering them and asserting they respond with `200 OK`. As long as `gem "showcase-rails"` is in the `:test` group you're set.
 

--- a/lib/tasks/showcase_tasks.rake
+++ b/lib/tasks/showcase_tasks.rake
@@ -2,8 +2,8 @@ namespace :showcase do
   namespace :install do
     INTEGRATION_TEST_PATH = "test/integration/showcase_test.rb"
 
-    desc "Install Showcase smokescreen testing in #{INTEGRATION_TEST_PATH}"
-    task :smokescreen_test do
+    desc "Install Showcase integration testing in #{INTEGRATION_TEST_PATH}"
+    task :integration_test do
       mkdir_p File.dirname(INTEGRATION_TEST_PATH)
       File.write INTEGRATION_TEST_PATH, <<~RUBY
         require "test_helper"


### PR DESCRIPTION
Looks like this was missed, probably in #16.