### PR TITLE
Remove unneeded copy task

### DIFF
--- a/lib/tasks/showcase_tasks.rake
+++ b/lib/tasks/showcase_tasks.rake
@@ -16,15 +16,4 @@ namespace :showcase do
       RUBY
     end
   end
-
-#   desc "Pass a directory relative to app/views to copy over"
-#   task :copy do |t, directory|
-#     prefix = "app/views/#{directory}"
-#
-#     Dir.glob(File.join(Dir.pwd, prefix, "**/*.*")).each do |filename|
-#       new_filename = filename.sub(directory, Showcase.templates_path).sub(/\/_/, "/")
-#       mkdir_p File.dirname(new_filename)
-#       copy_file filename, new_filename
-#     end
-#   end
 end


### PR DESCRIPTION
After #2, since we look up partials it's not as complicated to start Showcases. Users can grab a directory of partials and copy it into app/views/showcase/previews now. So let's omit the task for now.