### PR TITLE
Update actions/checkout to v3 for Node 16

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,7 +23,7 @@ jobs:
     runs-on: "ubuntu-latest"
 
     steps:
-      - uses: "actions/checkout@v2"
+      - uses: "actions/checkout@v3"
       - uses: "ruby/setup-ruby@v1"
         with:
           rubygems: 3.3.13


### PR DESCRIPTION
Fixes deprecation warning:

```
Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/
```

Seen here: https://github.com/kaspth/showcase/actions/runs/4154478314

Uses v3 as the deprecation warning link says.