### PR TITLE
Automatically attach a tailwind process when the server is booted

### DIFF
--- a/lib/showcase/engine.rb
+++ b/lib/showcase/engine.rb
@@ -9,5 +9,9 @@ module Showcase
     initializer "showcase.integration_test.autorun" do
       Showcase::IntegrationTest.autorun if Rails.env.test?
     end
+
+    server do
+      Process.detach spawn("bin/tailwindcss", "--watch", chdir: "../..") if Rails.env.development?
+    end
   end
 end


### PR DESCRIPTION
Uses the `server` hook to establish a bin/tailwindcss watch process.

We unsubscribe from the child process status with `detach` so no lingering zombie process left when the server shuts down. If we don't detach, we're left waiting for the process to exit and so the server never boots.

The process auto-inherits stdout and maybe stderr, so there's output in the terminal.