### PR TITLE
Fix path link hover styles being clobbered

### DIFF
--- a/app/assets/builds/showcase.css
+++ b/app/assets/builds/showcase.css
@@ -985,6 +985,14 @@ select {
   background-color: rgb(238 242 255 / var(--tw-bg-opacity));
 }
 
+.hover\:sc-text-inherit:hover {
+  color: inherit;
+}
+
+.hover\:sc-no-underline:hover {
+  text-decoration-line: none;
+}
+
 @media (min-width: 768px) {
   .md\:sc-text-lg {
     font-size: 1.125rem;

--- a/app/views/showcase/engine/path/_path.html.erb
+++ b/app/views/showcase/engine/path/_path.html.erb
@@ -1,3 +1,3 @@
 <article class="hover:sc-bg-indigo-50 <%= "sc-bg-indigo-50" if path.id == params[:id] %>">
-  <%= link_to path.basename.titleize, preview_path(path.id), class: "sc-inline-block sc-py-2 sc-px-8 sc-w-full" %>
+  <%= link_to path.basename.titleize, preview_path(path.id), class: "sc-inline-block sc-py-2 sc-px-8 sc-w-full hover:sc-text-inherit hover:sc-no-underline" %>
 </article>


### PR DESCRIPTION
Our Showcase styles on path links seem to be clobbered in Bullet Train apps by these styles that are inserted somewhere:

```css
a:hover {
  color: var(--secondary-600);
  text-decoration: underline;
}
```

I can't figure out where these styles are generated. But our links aren't sufficiently describing their CSS conditions, so we should fix their decoration regardless.