### PR TITLE
Render samples with shadowDOM to prevent style clashes.

### DIFF
--- a/app/assets/javascripts/showcase.js
+++ b/app/assets/javascripts/showcase.js
@@ -1,11 +1,16 @@
 window.customElements.define("showcase-isolated-context", class extends HTMLElement {
   constructor() {
     super()
-    this.attachShadow({ mode: "open" }).appendChild(this.#shadowRootContents)
+    this.attachShadow({ mode: "open" })
+  }
+
+  connectedCallback() {
+    if (!this.shadowRoot.length)
+      this.shadowRoot.appendChild(this.#shadowRootContents)
   }
 
   get #shadowRootContents() {
-    return this.querySelector("[data-shadowroot]").content.cloneNode(true)
+    return this.parentNode.querySelector("[data-shadowroot]").content.cloneNode(true)
   }
 })
 

--- a/app/assets/javascripts/showcase.js
+++ b/app/assets/javascripts/showcase.js
@@ -1,3 +1,14 @@
+window.customElements.define("showcase-isolated-context", class extends HTMLElement {
+  constructor() {
+    super()
+    this.attachShadow({ mode: "open" }).appendChild(this.#shadowRootContents)
+  }
+
+  get #shadowRootContents() {
+    return this.querySelector("[data-shadowroot]").content.cloneNode(true)
+  }
+})
+
 window.customElements.define("showcase-sample", class extends HTMLElement {
   connectedCallback() {
     this.events.forEach((name) => this.addEventListener(name, this.emit))

--- a/app/assets/javascripts/showcase.js
+++ b/app/assets/javascripts/showcase.js
@@ -2,15 +2,11 @@ window.customElements.define("showcase-isolated-context", class extends HTMLElem
   constructor() {
     super()
     this.attachShadow({ mode: "open" })
-  }
-
-  connectedCallback() {
-    if (!this.shadowRoot.length)
-      this.shadowRoot.appendChild(this.#shadowRootContents)
+    requestAnimationFrame(() => this.shadowRoot.appendChild(this.#shadowRootContents))
   }
 
   get #shadowRootContents() {
-    return this.parentNode.querySelector("[data-shadowroot]").content.cloneNode(true)
+    return this.querySelector("[data-shadowroot]").content.cloneNode(true)
   }
 })
 

--- a/app/assets/javascripts/showcase.js
+++ b/app/assets/javascripts/showcase.js
@@ -2,6 +2,9 @@ window.customElements.define("showcase-isolated-context", class extends HTMLElem
   constructor() {
     super()
     this.attachShadow({ mode: "open" })
+  }
+
+  connectedCallback() {
     requestAnimationFrame(() => this.shadowRoot.appendChild(this.#shadowRootContents))
   }
 

--- a/app/views/layouts/showcase.html.erb
+++ b/app/views/layouts/showcase.html.erb
@@ -5,7 +5,7 @@
     <meta name="viewport" content="width=device-width,initial-scale=1">
 
     <%= stylesheet_link_tag "showcase", "showcase.highlights" %>
-    <%= render "showcase/engine/javascripts" %>
+    <%= javascript_include_tag "showcase" %>
   </head>
 
   <body>

--- a/app/views/layouts/showcase.html.erb
+++ b/app/views/layouts/showcase.html.erb
@@ -4,7 +4,7 @@
     <title>Showcase</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
 
-    <%= render "showcase/engine/stylesheets" %>
+    <%= stylesheet_link_tag "showcase", "showcase.highlights" %>
     <%= render "showcase/engine/javascripts" %>
   </head>
 

--- a/app/views/showcase/engine/_sample.html.erb
+++ b/app/views/showcase/engine/_sample.html.erb
@@ -22,6 +22,7 @@
         <showcase-isolated-context>
           <template data-shadowroot>
             <%= render "showcase/engine/stylesheets" %>
+            <%= render "showcase/engine/javascripts" %>
             <%= sample.preview %>
           </template>
         </showcase-isolated-context>

--- a/app/views/showcase/engine/_sample.html.erb
+++ b/app/views/showcase/engine/_sample.html.erb
@@ -18,9 +18,14 @@
     </header>
 
     <% if sample.preview %>
-      <section class="sc-px-4 sc-py-2 sc-border sc-border-gray-200 sc-border-0 sc-border-b">
-        <%= sample.preview %>
-      </section>
+      <div class="sc-px-4 sc-py-2 sc-border sc-border-gray-200 sc-border-0 sc-border-b">
+        <showcase-isolated-context>
+          <template data-shadowroot shadowrootmode="open">
+            <%= render "showcase/engine/stylesheets" %>
+            <%= sample.preview %>
+          </template>
+        </showcase-isolated-context>
+      </div>
     <% end %>
 
     <% if sample.source %>

--- a/app/views/showcase/engine/_sample.html.erb
+++ b/app/views/showcase/engine/_sample.html.erb
@@ -19,12 +19,12 @@
 
     <% if sample.preview %>
       <section class="sc-px-4 sc-py-2 sc-border sc-border-gray-200 sc-border-0 sc-border-b">
-        <template data-shadowroot>
-          <%= render "showcase/engine/stylesheets" %>
-          <%= sample.preview %>
-        </template>
-
-        <showcase-isolated-context></showcase-isolated-context>
+        <showcase-isolated-context>
+          <template data-shadowroot>
+            <%= render "showcase/engine/stylesheets" %>
+            <%= sample.preview %>
+          </template>
+        </showcase-isolated-context>
       </section>
     <% end %>
 

--- a/app/views/showcase/engine/_sample.html.erb
+++ b/app/views/showcase/engine/_sample.html.erb
@@ -18,14 +18,14 @@
     </header>
 
     <% if sample.preview %>
-      <div class="sc-px-4 sc-py-2 sc-border sc-border-gray-200 sc-border-0 sc-border-b">
-        <showcase-isolated-context>
-          <template data-shadowroot shadowrootmode="open">
-            <%= render "showcase/engine/stylesheets" %>
-            <%= sample.preview %>
-          </template>
-        </showcase-isolated-context>
-      </div>
+      <section class="sc-px-4 sc-py-2 sc-border sc-border-gray-200 sc-border-0 sc-border-b">
+        <template data-shadowroot>
+          <%= render "showcase/engine/stylesheets" %>
+          <%= sample.preview %>
+        </template>
+
+        <showcase-isolated-context></showcase-isolated-context>
+      </section>
     <% end %>
 
     <% if sample.source %>

--- a/app/views/showcase/engine/_stylesheets.html.erb
+++ b/app/views/showcase/engine/_stylesheets.html.erb
@@ -1,1 +1,1 @@
-<%= stylesheet_link_tag "application", "showcase", "showcase.highlights" %>
+<%= stylesheet_link_tag "application" %>

--- a/test/controllers/showcase/previews_controller_test.rb
+++ b/test/controllers/showcase/previews_controller_test.rb
@@ -5,9 +5,11 @@ class Showcase::PreviewsControllerTest < Showcase::IntegrationTest
     get preview_path("button")
 
     assert_response :ok
-    within :section, "Samples" do
-      assert_button "Button content", class: %w[sc-text-xs]
-      assert_button "Button content", class: %w[sc-text-xl]
+    within :section, "Samples" do |section|
+      section.find_css("[data-shadowroot]") do
+        assert_button "Button content", class: %w[sc-text-xs]
+        assert_button "Button content", class: %w[sc-text-xl]
+      end
     end
 
     within :section, "Options" do
@@ -36,16 +38,18 @@ class Showcase::PreviewsControllerTest < Showcase::IntegrationTest
   test "#show renders samples" do
     get preview_path("stimulus_controllers/welcome")
 
-    within :section, "Samples" do
-      assert_region "Basic", text: "I've just said welcome!"
-      within :region, "With greeter" do
-        within :element, data: {controller: "welcome"} do
-          assert_element text: "Somebody", data: {welcome_target: "greeter"}
+    within :section, "Samples" do |section|
+      section.find_css "[data-shadowroot]" do
+        assert_region "Basic", text: "I've just said welcome!"
+        within :region, "With greeter" do
+          within :element, data: {controller: "welcome"} do
+            assert_element text: "Somebody", data: {welcome_target: "greeter"}
+          end
         end
-      end
-
-      within :region, "Yelling!!!" do
-        assert_element data: {controller: "welcome", welcome_yell_value: "true"}
+  
+        within :region, "Yelling!!!" do
+          assert_element data: {controller: "welcome", welcome_yell_value: "true"}
+        end
       end
     end
   end
@@ -78,7 +82,11 @@ class Showcase::PreviewsControllerTest < Showcase::IntegrationTest
 
     get preview_path("link")
 
-    assert_link "root", href: "/main_app_root"
+    within :section, "Samples" do |section|
+      section.find_css "[data-shadowroot]" do
+        assert_link "root", href: "/main_app_root"
+      end
+    end
   end
 
   test "#show renders Custom sample partials" do

--- a/test/dummy/app/views/showcase/engine/_javascripts.html.erb
+++ b/test/dummy/app/views/showcase/engine/_javascripts.html.erb
@@ -1,4 +1,4 @@
-<%= javascript_include_tag "application", "showcase" %>
+<%= javascript_include_tag "application" %>
 
 <script type="module">
   import { Application, Controller } from "https://unpkg.com/@hotwired/stimulus/dist/stimulus.js"

--- a/test/views/showcase/previews/_sample.html.erb_test.rb
+++ b/test/views/showcase/previews/_sample.html.erb_test.rb
@@ -23,7 +23,9 @@ module Showcase::Previews
       render "showcase/engine/sample", sample: sample
 
       assert_element "showcase-sample" do |showcase_sample|
-        showcase_sample.assert_text "ERB"
+        showcase_sample.find_css "[data-shadowroot]" do
+          showcase_sample.assert_text "ERB"
+        end
         showcase_sample.assert_disclosure "View Source", expanded: false
       end
     end


### PR DESCRIPTION
This renders our samples with shadowDOM on a custom element, so we can embed app styles in those elements and not have them leak into Showcase.