### PR TITLE
Yank the previews test autorun

### DIFF
--- a/README.md
+++ b/README.md
@@ -56,9 +56,9 @@ end
 
 ## Automatic previews testing
 
-Showcase automatically runs tests for all your Showcases by rendering them. As long as `gem "showcase-rails"` is in the `:test` group you're set.
+Showcase can automatically generate tests for all your Showcases to have it executed in your CI setup, run `bin/rails showcase:install:previews_test` to set this up.
 
-If you want to tweak this, run `bin/rails showcase:install:previews_test` and open `test/views/showcase_test.rb`. You can then add your own `setup` and `teardown` hooks, as well as override the provided `assert_showcase_preview` to add custom assertions.
+ You can then open `test/views/showcase_test.rb` and add your own `setup` and `teardown` hooks, as well as override the provided `assert_showcase_preview` to add custom assertions.
 
 If you need custom assertions for specific previews and their samples, you can use the `test` helper:
 

--- a/lib/showcase/engine.rb
+++ b/lib/showcase/engine.rb
@@ -5,9 +5,5 @@ module Showcase
     initializer "showcase.assets" do
       config.assets.precompile += %w[showcase_manifest]
     end
-
-    initializer "showcase.previews_test.autorun" do
-      Showcase::PreviewsTest.autorun if Rails.env.test?
-    end
   end
 end

--- a/lib/showcase/previews_test.rb
+++ b/lib/showcase/previews_test.rb
@@ -4,10 +4,6 @@ class Showcase::PreviewsTest < ActionView::TestCase
     test_class.prepare
   end
 
-  def self.autorun
-    at_exit { prepare unless subclasses.any? }
-  end
-
   def self.prepare
     tests Showcase::EngineController._helpers
 


### PR DESCRIPTION
Fixes https://github.com/bullet-train-co/bullet_train-core/issues/140

If you run an individual test file with `bin/rails test/models/post_test.rb`, Showcase will think you're trying to autorun its view tests and won't use any overridden file in `test/views/showcase_test.rb` because it's not loaded.

While the autorun setup could be neat, it'll have interference so let's have users run the task manually.