### PR TITLE
Extract showcase/engine/_head to capture application head details

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,8 +16,8 @@ jobs:
           - "7.0"
           - "main"
         rouge-bundled:
-          - "true"
-          - "false"
+          - true
+          - false
 
     env:
       RAILS_VERSION: ${{ matrix.rails-version }}
@@ -38,7 +38,7 @@ jobs:
         run: bin/rails runner 'require "tailwindcss-rails"; `bin/tailwindcss`'
 
       - name: Build Highlight Styles with rouge
-        run: bin/rails runner 'return if ENV["ROUGE_BUNDLED"] == "false"; require "rouge"; `bin/highlights`'
+        run: bin/rails runner 'if ENV["ROUGE_BUNDLED"] == "true"; require "rouge"; `bin/highlights`; end'
 
       - name: Execute Test Suite
         run: bin/rails test test/**/*_test.rb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: bin/rails runner 'require "tailwindcss-rails"; `bin/tailwindcss`'
 
       - name: Build Highlight Styles with rouge
-        run: bin/rails runner 'return if ENV["ROUGE_BUNDLED"] == "false"; require "rouge"; `bin/highlight`"
+        run: bin/rails runner 'return if ENV["ROUGE_BUNDLED"] == "false"; require "rouge"; `bin/highlight`'
 
       - name: Execute Test Suite
         run: bin/rails test test/**/*_test.rb

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
         run: bin/rails runner 'require "tailwindcss-rails"; `bin/tailwindcss`'
 
       - name: Build Highlight Styles with rouge
-        run: bin/rails runner 'return if ENV["ROUGE_BUNDLED"] == "false"; require "rouge"; `bin/highlight`'
+        run: bin/rails runner 'return if ENV["ROUGE_BUNDLED"] == "false"; require "rouge"; `bin/highlights`'
 
       - name: Execute Test Suite
         run: bin/rails test test/**/*_test.rb

--- a/README.md
+++ b/README.md
@@ -157,12 +157,16 @@ Showcase bundles its own `showcase.js`, `showcase.css` and `showcase.highlights.
 Action View's [javascript_include_tag][] and [stylesheet_link_tag][].
 
 If your assets require more sophisticated loading techniques, declare your own
-versions of the [showcase/engine/_javascripts.html.erb][] and
+version of the [showcase/engine/_head.html.erb][] partial.
+
+If you need to tweak showcase's assets, declare your own versions of
+the [showcase/engine/_javascripts.html.erb][] and
 [showcase/engine/_stylesheets.html.erb][] partials. When customizing those
 partials, make sure to include `"showcase"` in your list of assets.
 
 [javascript_include_tag]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-javascript_include_tag
 [stylesheet_link_tag]: https://edgeapi.rubyonrails.org/classes/ActionView/Helpers/AssetTagHelper.html#method-i-stylesheet_link_tag
+[showcase/engine/_head.html.erb]: ./showcase/engine/_head.html.erb
 [showcase/engine/_javascripts.html.erb]: ./showcase/engine/_javascripts.html.erb
 [showcase/engine/_stylesheets.html.erb]: ./showcase/engine/_stylesheets.html.erb
 

--- a/app/views/layouts/showcase.html.erb
+++ b/app/views/layouts/showcase.html.erb
@@ -4,6 +4,7 @@
     <title>Showcase</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
 
+    <%= render "showcase/engine/head" %>
     <%= render "showcase/engine/stylesheets" %>
     <%= render "showcase/engine/javascripts" %>
   </head>

--- a/app/views/showcase/engine/_head.html.erb
+++ b/app/views/showcase/engine/_head.html.erb
@@ -1,0 +1,2 @@
+<%= stylesheet_link_tag "application" %>
+<%= javascript_include_tag "application" %>

--- a/app/views/showcase/engine/_javascripts.html.erb
+++ b/app/views/showcase/engine/_javascripts.html.erb
@@ -1,1 +1,1 @@
-<%= javascript_include_tag "application", "showcase" %>
+<%= javascript_include_tag "showcase" %>

--- a/app/views/showcase/engine/_stylesheets.html.erb
+++ b/app/views/showcase/engine/_stylesheets.html.erb
@@ -1,1 +1,1 @@
-<%= stylesheet_link_tag "application", "showcase", "showcase.highlights" %>
+<%= stylesheet_link_tag "showcase", "showcase.highlights" %>

--- a/test/dummy/app/views/showcase/engine/_javascripts.html.erb
+++ b/test/dummy/app/views/showcase/engine/_javascripts.html.erb
@@ -1,4 +1,4 @@
-<%= javascript_include_tag "application", "showcase" %>
+<%= javascript_include_tag "showcase" %>
 
 <script type="module">
   import { Application, Controller } from "https://unpkg.com/@hotwired/stimulus/dist/stimulus.js"


### PR DESCRIPTION
Applications may carry more advanced setups that we need to capture, which aren't strictly asset declarations — and they may not need to override Showcase's internal assets.

So we can extract a showcase/engine/_head partial to capture these details.