### PR TITLE
Call `preview_path` route through Engine's mounted helper name

### DIFF
--- a/app/views/showcase/engine/path/_path.html.erb
+++ b/app/views/showcase/engine/path/_path.html.erb
@@ -1,3 +1,3 @@
 <article class="hover:sc-bg-indigo-50 dark:hover:sc-bg-neutral-700/50 <%= "sc-bg-indigo-50 dark:sc-bg-neutral-700/50" if path.id == params[:id] %>">
-  <%= link_to path.basename.titleize, preview_path(path.id), class: "sc-inline-block sc-py-2 sc-px-8 sc-w-full !sc-text-inherit !sc-no-underline" %>
+  <%= link_to path.basename.titleize, showcase.preview_path(path.id), class: "sc-inline-block sc-py-2 sc-px-8 sc-w-full !sc-text-inherit !sc-no-underline" %>
 </article>


### PR DESCRIPTION
Happened on a client that used Rails 6.1.x where Sprockets somehow would intercept the route and call the assets route. I couldn't figure out how to get to the root of the issue, but this seems to fix it while working on newer Rails versions.

We may be able to remove this once Rails 7.0+ is the minimum version requirement.

Note: due to how Rails Engine's work people can break our code by doing `mount Showcase::Engine, as: :another_name` as the mounted helper will then be `another_name` instead of `showcase`.