### PR TITLE
Revert "Call `preview_path` route through Engine's mounted helper name"

### DIFF
--- a/app/views/showcase/engine/path/_path.html.erb
+++ b/app/views/showcase/engine/path/_path.html.erb
@@ -1,3 +1,3 @@
 <article class="hover:sc-bg-indigo-50 dark:hover:sc-bg-neutral-700/50 <%= "sc-bg-indigo-50 dark:sc-bg-neutral-700/50" if path.id == params[:id] %>">
-  <%= link_to path.basename.titleize, showcase.preview_path(path.id), class: "sc-inline-block sc-py-2 sc-px-8 sc-w-full !sc-text-inherit !sc-no-underline" %>
+  <%= link_to path.basename.titleize, preview_path(path.id), class: "sc-inline-block sc-py-2 sc-px-8 sc-w-full !sc-text-inherit !sc-no-underline" %>
 </article>


### PR DESCRIPTION
Reverts bullet-train-co/showcase#49

I figured out how to reproduce this. It was caused by an `include Rails.application.routes.url_helpers` in a helper in `app/helpers`, which then polluted our Showcase view context with the app routes.

That's pretty uncommon, so I just went with reverting the "fix" for now. We can revisit the helper automatic application helper includes another time if need be.