### PR TITLE
Fix `extract` in ERB templates + refactor

### DIFF
--- a/app/models/showcase/sample.rb
+++ b/app/models/showcase/sample.rb
@@ -41,7 +41,7 @@ class Showcase::Sample
   private
 
   def extract_source_block_via_matched_indentation_from(file, starting_index)
-    first_line, *lines = File.readlines(file).from(starting_index.pred)
+    first_line, *lines = File.readlines(file).slice(starting_index.pred..)
 
     indentation = first_line.match(/^\s+(?=\b)/).to_s
     matcher = /^#{indentation}\S/

--- a/app/models/showcase/sample.rb
+++ b/app/models/showcase/sample.rb
@@ -41,7 +41,7 @@ class Showcase::Sample
   private
 
   def extract_source_block_via_matched_indentation_from(file, starting_index)
-    first_line, *lines = File.readlines(file).from(starting_index - 1)
+    first_line, *lines = File.readlines(file).from(starting_index.pred)
 
     indentation = first_line.match(/^\s+(?=\b)/).to_s
     matcher = /^#{indentation}\S/

--- a/app/models/showcase/sample.rb
+++ b/app/models/showcase/sample.rb
@@ -41,9 +41,9 @@ class Showcase::Sample
   private
 
   def extract_source_block_via_matched_indentation_from(file, starting_index)
-    first_line, *lines = File.readlines(file).slice(starting_index.pred..)
+    starting_line, *lines = File.readlines(file).slice(starting_index.pred..)
 
-    indentation = first_line.match(/^\s+(?=\b)/).to_s
+    indentation = starting_line.match(/^\s+(?=\b)/).to_s
     matcher = /^#{indentation}\S/
 
     index = lines.index { _1.match?(matcher) }

--- a/app/models/showcase/sample.rb
+++ b/app/models/showcase/sample.rb
@@ -40,8 +40,9 @@ class Showcase::Sample
 
   private
 
-  def extract_source_block_via_matched_indentation_from(file, starting_index)
-    starting_line, *lines = File.readlines(file).slice(starting_index.pred..)
+  def extract_source_block_via_matched_indentation_from(file, source_location_index)
+    # `Array`s are zero-indexed, but `source_location` indexes are not, hence `pred`.
+    starting_line, *lines = File.readlines(file).slice(source_location_index.pred..)
 
     indentation = starting_line.match(/^\s+/).to_s
     matcher = /^#{indentation}\S/

--- a/app/models/showcase/sample.rb
+++ b/app/models/showcase/sample.rb
@@ -43,7 +43,7 @@ class Showcase::Sample
   def extract_source_block_via_matched_indentation_from(file, starting_index)
     starting_line, *lines = File.readlines(file).slice(starting_index.pred..)
 
-    indentation = starting_line.match(/^\s+(?=\b)/).to_s
+    indentation = starting_line.match(/^\s+/).to_s
     matcher = /^#{indentation}\S/
 
     index = lines.index { _1.match?(matcher) }

--- a/test/dummy/app/views/showcase/previews/helpers/_upcase_helper.html.erb
+++ b/test/dummy/app/views/showcase/previews/helpers/_upcase_helper.html.erb
@@ -1,3 +1,13 @@
 <% showcase.sample "Basic" do %>
   <%= upcase_string "hello" %>
 <% end %>
+
+<% showcase.sample "With extract" do |sample| %>
+  <% sample.preview do %>
+    EXTRACT
+  <% end %>
+
+  <% sample.extract do %>
+    <%= upcase_string "extract" %>
+  <% end %>
+<% end %>

--- a/test/views/showcase_test.rb
+++ b/test/views/showcase_test.rb
@@ -31,6 +31,12 @@ class ShowcaseTest < Showcase::PreviewsTest
     assert_method "test_Showcase:_showcase/previews/components/combobox_sample_basic"
   end
 
+  test showcase: "helpers/upcase_helper" do
+    assert_element id: "with-extract" do
+      assert_text /<%= upcase_string "extract" %>\Z/, normalize_ws: true
+    end
+  end
+
   private
 
   def assert_method(name)


### PR DESCRIPTION
In the case of a sample's preview and source code being different we would end up revealing a `<% end %>` at the end of View Source, e.g.:

```erb
<% showcase.sample "Basic" do |sample| %>
  <% sample.extract do %>
     Wasssup
  <% end %><%# This end would be appear in View Source %>
<% end %>
```

This fixes that and refactors some of the code while we're here.