### PR TITLE
Don't use internal assert_element helper in generated tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,9 +99,10 @@ class ShowcaseTest < Showcase::PreviewsTest
     assert_text "This is a combobox, for sure."
   end
 
-  test showcase: "button", id: "basic" do
-    # This test block runs within the #button container element's #basic sample.
-    assert_button class: ["text-xs"]
+  test showcase: "button" do
+    assert_selector id: "basic" do
+      assert_button class: ["text-xs"]
+    end
   end
 
   test "some non-Showcase test" do

--- a/lib/showcase/previews_test.rb
+++ b/lib/showcase/previews_test.rb
@@ -1,12 +1,12 @@
 class Showcase::PreviewsTest < ActionView::TestCase
   def self.inherited(test_class)
     super
+
+    test_class.tests Showcase::EngineController._helpers
     test_class.prepare
   end
 
   def self.prepare
-    tests Showcase::EngineController._helpers
-
     tree = Showcase::Path.tree
     tree.flat_map(&:ordered_paths).each do |path|
       test "Showcase: automatically renders showcase/previews/#{path.id}" do

--- a/lib/showcase/previews_test.rb
+++ b/lib/showcase/previews_test.rb
@@ -20,17 +20,16 @@ class Showcase::PreviewsTest < ActionView::TestCase
     end
   end
 
-  def self.test(name = nil, showcase: nil, id: nil, &block)
-    case
-    when name then super(name, &block)
-    when id && showcase.nil? then raise ArgumentError, "can't test a sample without a showcase"
+  def self.test(name = nil, showcase: nil, &block)
+    if name
+      super(name, &block)
     else
-      super "Showcase: showcase/previews/#{showcase} #{"sample #{id}" if id}".squish do
+      super "Showcase: showcase/previews/#{showcase}" do
         path = Showcase::Path.new(showcase)
         render "showcase/engine/preview", preview: path.preview_for(view)
 
         assert_showcase_preview(path.id)
-        assert_element(id: id || path.id) { instance_eval(&block) }
+        instance_eval(&block)
       end
     end
   end

--- a/test/views/showcase_test.rb
+++ b/test/views/showcase_test.rb
@@ -19,16 +19,8 @@ class ShowcaseTest < Showcase::PreviewsTest
     end
   end
 
-  test showcase: "components/combobox", id: "basic" do
-    assert_text "This is totally a combobox, for sure."
-  end
-
   test "showcase generated a components/combobox test" do
     assert_method "test_Showcase:_showcase/previews/components/combobox"
-  end
-
-  test "showcase generated a components/combobox basic sample test" do
-    assert_method "test_Showcase:_showcase/previews/components/combobox_sample_basic"
   end
 
   test showcase: "helpers/upcase_helper" do


### PR DESCRIPTION
Means we have to chop the `id:` support, which is probably simpler really.