### PR TITLE
Remove obsolete previews_path configuration

### DIFF
--- a/app/models/showcase/preview.rb
+++ b/app/models/showcase/preview.rb
@@ -88,7 +88,7 @@ class Showcase::Preview
   end
 
   def render_associated_partial
-    @view_context.render "#{Showcase.previews_path}/#{id}", showcase: self
+    @view_context.render "showcase/previews/#{id}", showcase: self
     nil
   end
 end

--- a/lib/showcase.rb
+++ b/lib/showcase.rb
@@ -24,12 +24,9 @@ module Showcase
     end
   end
 
-  singleton_class.attr_reader :previews_path
-  @previews_path = "showcase/previews"
-
   def self.previews
     Showcase::EngineController.view_paths.map(&:path).flat_map do |root|
-      Dir.glob("**/*.*", base: File.join(root, previews_path))
+      Dir.glob("**/*.*", base: File.join(root, "showcase/previews"))
     end.uniq
   end
 


### PR DESCRIPTION
If people change this, we'll no longer look up previews in engines.