### PR TITLE
Fix testing of linking to other showcases

### DIFF
--- a/lib/showcase/previews_test.rb
+++ b/lib/showcase/previews_test.rb
@@ -1,8 +1,9 @@
 class Showcase::PreviewsTest < ActionView::TestCase
+  extensions = [ Showcase::EngineController._helpers, Showcase::Engine.routes.url_helpers ]
+  setup { view.extend *extensions }
+
   def self.inherited(test_class)
     super
-
-    test_class.tests Showcase::EngineController._helpers
     test_class.prepare
   end
 

--- a/test/dummy/app/views/showcase/previews/helpers/_upcase_helper.html.erb
+++ b/test/dummy/app/views/showcase/previews/helpers/_upcase_helper.html.erb
@@ -1,3 +1,7 @@
+<% showcase.description do %>
+  Be sure to check out <%= link_to "plain_ruby", preview_path("plain_ruby") %>.
+<% end %>
+
 <% showcase.sample "Basic" do %>
   <%= upcase_string "hello" %>
 <% end %>


### PR DESCRIPTION
`preview_path` worked fine when visiting Showcases in the browser, but it failed in tests since the ActionView::TestCase harness don't know about the routes.

We may want to revisit the choice to use ActionView::TestCase in the future.