### PR TITLE
Fix `removeEventListener` calls

### DIFF
--- a/app/assets/javascripts/showcase.js
+++ b/app/assets/javascripts/showcase.js
@@ -4,7 +4,7 @@ window.customElements.define("showcase-sample", class extends HTMLElement {
   }
 
   disconnectedCallback() {
-    this.events.forEach(this.removeEventListener)
+    this.events.forEach((name) => this.removeEventListener(name, this.emit))
   }
 
   emit(event) {


### PR DESCRIPTION
I spotted an error in the console, which lead to a TIL.

`removeEventListener` needs to have the same arguments passed to `addEventListener` to work.

So this fixes those calls and the thrown error.