### PR TITLE
Let users control trees being open or not

### DIFF
--- a/app/models/showcase/path.rb
+++ b/app/models/showcase/path.rb
@@ -14,7 +14,7 @@ class Showcase::Path
     end
 
     def open?
-      Showcase.tree_opener.call(self)
+      Showcase.tree_opens.call(self)
     end
 
     def ordered_children

--- a/app/models/showcase/path.rb
+++ b/app/models/showcase/path.rb
@@ -13,6 +13,10 @@ class Showcase::Path
       id == "." ? "Previews" : id
     end
 
+    def open?
+      Showcase.tree_opener.call(self)
+    end
+
     def ordered_children
       children.partition { !_1.is_a?(Tree) }.flatten
     end

--- a/app/views/showcase/engine/path/_tree.html.erb
+++ b/app/views/showcase/engine/path/_tree.html.erb
@@ -1,4 +1,4 @@
-<%= tag.details open: tree.open?, class: ["sc-flex sc-flex-col", "sc-pl-4" => tree.root?] %>
+<%= tag.details open: tree.open?, class: ["sc-flex sc-flex-col", "sc-pl-4" => !tree.root?] do %>
   <%= tag.summary tree.name.titleize, class: "sc-list-item hover:sc-bg-indigo-50 dark:hover:sc-bg-neutral-700/50 sc-font-medium sc-text-base sc-py-2 sc-pl-4 sc-cursor-pointer" %>
   <%= render tree.ordered_children %>
 <% end %>

--- a/app/views/showcase/engine/path/_tree.html.erb
+++ b/app/views/showcase/engine/path/_tree.html.erb
@@ -1,4 +1,4 @@
-<details open class="sc-flex sc-flex-col <%= "sc-pl-4" unless tree.root? %>">
+<%= tag.details open: tree.open?, class: ["sc-flex sc-flex-col", "sc-pl-4" => tree.root?] %>
   <%= tag.summary tree.name.titleize, class: "sc-list-item hover:sc-bg-indigo-50 dark:hover:sc-bg-neutral-700/50 sc-font-medium sc-text-base sc-py-2 sc-pl-4 sc-cursor-pointer" %>
   <%= render tree.ordered_children %>
-</details>
+<% end %>

--- a/lib/showcase.rb
+++ b/lib/showcase.rb
@@ -13,17 +13,15 @@ module Showcase
   autoload :Options,      "showcase/options"
 
   class << self
-    attr_reader :tree_opener
+    attr_reader :tree_opens
 
-    def tree_opener=(opener)
-      @tree_opener = opener.respond_to?(:call) ? opener : proc { opener }
+    def tree_opens=(opens)
+      @tree_opens = opens.respond_to?(:call) ? opens : proc { opens }
     end
   end
-  self.tree_opener = true
-
-  self.tree_opener = true  # All open
-  self.tree_opener = false # All closed by default
-  self.tree_opener = ->(tree) { tree.root? } # Just keep the root-level trees open.
+  self.tree_opens = true # All open by default
+  # self.tree_opens = false # All closed by default
+  # self.tree_opens = ->(tree) { tree.root? } # Just keep the root-level trees open.
 
   singleton_class.attr_accessor :sample_renderer
   @sample_renderer = proc { _1 }

--- a/lib/showcase.rb
+++ b/lib/showcase.rb
@@ -12,6 +12,19 @@ module Showcase
   autoload :RouteHelper,  "showcase/route_helper"
   autoload :Options,      "showcase/options"
 
+  class << self
+    attr_reader :tree_opener
+
+    def tree_opener=(opener)
+      @tree_opener = opener.respond_to?(:call) ? opener : proc { opener }
+    end
+  end
+  self.tree_opener = true
+
+  self.tree_opener = true  # All open
+  self.tree_opener = false # All closed by default
+  self.tree_opener = ->(tree) { tree.root? } # Just keep the root-level trees open.
+
   singleton_class.attr_accessor :sample_renderer
   @sample_renderer = proc { _1 }
 

--- a/test/views/showcase/engine/path/_tree.html.erb_test.rb
+++ b/test/views/showcase/engine/path/_tree.html.erb_test.rb
@@ -1,0 +1,37 @@
+require "test_helper"
+
+module Showcase::Engine::Path
+  class TreePartialTest < ActionView::TestCase
+    setup    { @old_opens = Showcase.tree_opens }
+    teardown { Showcase.tree_opens = @old_opens }
+
+    test "tree_opens true" do
+      Showcase.tree_opens = true
+      render "showcase/engine/path/tree", tree: Showcase::Path::Tree.new(".")
+      render "showcase/engine/path/tree", tree: Showcase::Path::Tree.new("helpers")
+      assert_disclosure "Previews", expanded: true
+      assert_disclosure "Helpers", expanded: true
+    end
+
+    test "tree_opens false" do
+      Showcase.tree_opens = false
+      render "showcase/engine/path/tree", tree: Showcase::Path::Tree.new(".")
+      render "showcase/engine/path/tree", tree: Showcase::Path::Tree.new("helpers")
+      assert_disclosure "Previews", expanded: false
+      assert_disclosure "Helpers", expanded: false
+    end
+
+    test "tree_opens just root trees" do
+      tree = Showcase::Path::Tree.new("deeply")
+      tree.root = true
+      tree.edge_for("nested")
+
+      Showcase.tree_opens = ->(tree) { tree.root? }
+      render "showcase/engine/path/tree", tree: Showcase::Path::Tree.new(".")
+      render "showcase/engine/path/tree", tree: tree
+      assert_disclosure "Previews", expanded: false
+      assert_disclosure "Deeply", expanded: true
+      assert_disclosure "Nested", expanded: false
+    end
+  end
+end


### PR DESCRIPTION
```ruby
# config/initializers/showcase.rb
return unless defined?(Showcase)

Showcase.tree_opens = true  # Open all the trees (the default).
Showcase.tree_opens = false # Close all the trees.
Showcase.tree_opens = ->(tree) { tree.root? } # Only open the root level trees.
Showcase.tree_opens = ->(tree) { tree.id.start_with? ".", "stimulus" } # Just open the top-level trees and the Stimulus tree.
```