### PR TITLE
Allow text in a table to wrap

### DIFF
--- a/app/views/showcase/engine/_options.html.erb
+++ b/app/views/showcase/engine/_options.html.erb
@@ -19,7 +19,7 @@
                 <%= tag.input type: :checkbox, checked: value, disabled: true if value%>
               </td>
             <% else %>
-              <td class="sc-p-4"><%= tag.pre value %></td>
+              <td class="sc-p-4"><%= tag.pre value, class: 'whitespace-normal' %></td>
             <% end %>
           <% end %>
         </tr>


### PR DESCRIPTION
This PR adds `sc-whitespace-normal` to the pre tag within table cells to allow the text to wrap normally and prevent large horizontal scrolling tables.

https://www.loom.com/share/05dac229aa3f4a0fbdf6c6a145bb37ec