### PR TITLE
Fix accessing app routes in tests.

### DIFF
--- a/app/models/showcase/preview.rb
+++ b/app/models/showcase/preview.rb
@@ -43,7 +43,7 @@ class Showcase::Preview
   #   <%= showcase.link_to id: "extra-large" %>
   #   # => <a href="components/button#extra-large"><showcase components/button#extra-large></a>
   def link_to(preview_id = id, id: nil)
-    @view_context.link_to @view_context.preview_path(preview_id, anchor: id), class: "sc-link sc-font-mono sc-text-sm" do
+    @view_context.link_to Showcase::Engine.routes.url_helpers.preview_path(preview_id, anchor: id), class: "sc-link sc-font-mono sc-text-sm" do
       "<showcase #{[preview_id, id].compact.join("#").squish}>"
     end
   end

--- a/lib/showcase/previews_test.rb
+++ b/lib/showcase/previews_test.rb
@@ -1,6 +1,5 @@
 class Showcase::PreviewsTest < ActionView::TestCase
-  extensions = [ Showcase::EngineController._helpers, Showcase::Engine.routes.url_helpers ]
-  setup { view.extend *extensions }
+  setup { view.extend Showcase::EngineController._helpers }
 
   def self.inherited(test_class)
     super


### PR DESCRIPTION
Normally in `ActionView::TestCase` tests, routes point to an internal TestController's routes that match `Rails.application.routes`.

However, by doing `view.extend Showcase::EngineController.routes.url_helpers` we'd override the view's `_routes` method to point to `Showcase::Engine.routes`.

This meant that the view already having included the app routes, our `Showcase::RouteHelper#method_missing` would never be triggered, since we respond to the app route.

However, `_routes` now point to the engine route set, we'd raise a MissingRoute exception since it knows nothing about the app routes.

Note: we're going through `Showcase::Engine.routes.url_helpers` versus `@view_context.showcase` to prevent relying on our chosen `mount` name, since apps can override that.