### PR TITLE
Preserve sidebar state for Rails apps that use Turbo

### DIFF
--- a/app/views/showcase/engine/_root.html.erb
+++ b/app/views/showcase/engine/_root.html.erb
@@ -1,6 +1,10 @@
 <main class="sc-flex sc-flex-wrap dark:sc-bg-neutral-900 dark:sc-text-white" aria-labelledby="showcase_main_title">
   <section class="sc-grid sc-grid-cols-12 sc-w-full">
-    <nav class="sc-col-span-3 xl:sc-col-span-2 sc-h-full sc-border-0 sc-border-r sc-border-solid sc-border-gray-200">
+    <nav
+      id="showcase-nav"
+      data-turbo-permanent
+      class="sc-col-span-3 xl:sc-col-span-2 sc-h-full sc-border-0 sc-border-r sc-border-solid sc-border-gray-200"
+    >
       <h1 id="showcase_main_title" class="sc-font-black sc-text-2xl sc-m-0">
         <%= link_to "Showcase", root_url, class: "sc-link sc-block sc-pt-5 sc-pb-2 sc-pl-4" %>
       </h1>


### PR DESCRIPTION
In this commit, we add a new `data-turbo-permanent` attribute to the showcase tree sidebar.

This enables Rails applications that use Turbo to preserve the state of open/closed details/summary in the tree sidebar.

It will have no effect on Rails applications that do not use Turbo.