### PR TITLE
Defer Rouge load to save on boot time.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -20,7 +20,7 @@ gem "sprockets-rails"
 # Start debugger with binding.b [https://github.com/ruby/debug]
 # gem "debug", ">= 1.0.0"
 
-gem "puma", "~> 5.6"
+gem "puma"
 
 gem "rouge"
 

--- a/Gemfile
+++ b/Gemfile
@@ -22,7 +22,7 @@ gem "sprockets-rails"
 
 gem "puma"
 
-gem "rouge"
+gem "rouge", require: false
 
 group :test do
   gem "action_dispatch-testing-integration-capybara",

--- a/README.md
+++ b/README.md
@@ -175,7 +175,7 @@ Add these lines to your application's Gemfile. See next section for why Showcase
 ```ruby
 group :development, :test do
   gem "showcase-rails"
-  gem "rouge" # Optional. For out-of-the-box syntax highlighting.
+  gem "rouge", require: false # Syntax highlighting, `require: false` lets Showcase handle loading and saves boot time.
 end
 ```
 
@@ -228,7 +228,7 @@ end
 
 ### Syntax Highlighting
 
-Add `gem "rouge"` to your Gemfile and Showcase will set syntax highlighting up for you. Any denoted syntaxes in your samples are then highlighted, e.g.:
+Add `gem "rouge", require: false` to your Gemfile and Showcase will set syntax highlighting up for you. Any denoted syntaxes in your samples are then highlighted, e.g.:
 
 ```erb
 # app/views/showcase/previews/_plain_ruby.ruby


### PR DESCRIPTION
Looks like Rouge takes a fair amount of time to load ~60ms-150ms. So it's better we defer this until we need it.

This lets apps set `gem "rouge", require: false"` too and let Showcase handle the load.