### PR TITLE
Revert "Preserve sidebar state for Rails apps that use Turbo"

### DIFF
--- a/app/views/showcase/engine/_root.html.erb
+++ b/app/views/showcase/engine/_root.html.erb
@@ -1,10 +1,6 @@
 <main class="sc-flex sc-flex-wrap dark:sc-bg-neutral-900 dark:sc-text-white" aria-labelledby="showcase_main_title">
   <section class="sc-grid sc-grid-cols-12 sc-w-full">
-    <nav
-      id="showcase-nav"
-      data-turbo-permanent
-      class="sc-col-span-3 xl:sc-col-span-2 sc-h-full sc-border-0 sc-border-r sc-border-solid sc-border-gray-200"
-    >
+    <nav class="sc-col-span-3 xl:sc-col-span-2 sc-h-full sc-border-0 sc-border-r sc-border-solid sc-border-gray-200">
       <h1 id="showcase_main_title" class="sc-font-black sc-text-2xl sc-m-0">
         <%= link_to "Showcase", root_url, class: "sc-link sc-block sc-pt-5 sc-pb-2 sc-pl-4" %>
       </h1>


### PR DESCRIPTION
Reverts bullet-train-co/showcase#71

We're reverting this to avoid the need for custom JavaScript to keep the active element in the sidebar, since that seems a little too costly for this.

cc @alexandreruban