### PR TITLE
Add a light/dark mode toggle in the UI

### DIFF
--- a/app/assets/builds/showcase.css
+++ b/app/assets/builds/showcase.css
@@ -191,6 +191,10 @@ pre {
   display: list-item;
 }
 
+.sc-hidden {
+  display: none;
+}
+
 .sc-h-full {
   height: 100%;
 }
@@ -239,6 +243,10 @@ pre {
 
 .sc-items-center {
   align-items: center;
+}
+
+.sc-items-baseline {
+  align-items: baseline;
 }
 
 .sc-justify-between {
@@ -479,33 +487,39 @@ pre {
   background-color: rgb(238 242 255 / var(--tw-bg-opacity));
 }
 
-@media (prefers-color-scheme: dark) {
-  .dark\:sc-bg-neutral-700\/50 {
-    background-color: rgb(64 64 64 / 0.5);
-  }
+:is(.sc-dark .dark\:sc-block) {
+  display: block;
+}
 
-  .dark\:sc-bg-neutral-800 {
-    --tw-bg-opacity: 1;
-    background-color: rgb(38 38 38 / var(--tw-bg-opacity));
-  }
+:is(.sc-dark .dark\:sc-hidden) {
+  display: none;
+}
 
-  .dark\:sc-bg-neutral-900 {
-    --tw-bg-opacity: 1;
-    background-color: rgb(23 23 23 / var(--tw-bg-opacity));
-  }
+:is(.sc-dark .dark\:sc-bg-neutral-700\/50) {
+  background-color: rgb(64 64 64 / 0.5);
+}
 
-  .dark\:sc-text-inherit {
-    color: inherit;
-  }
+:is(.sc-dark .dark\:sc-bg-neutral-800) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(38 38 38 / var(--tw-bg-opacity));
+}
 
-  .dark\:sc-text-white {
-    --tw-text-opacity: 1;
-    color: rgb(255 255 255 / var(--tw-text-opacity));
-  }
+:is(.sc-dark .dark\:sc-bg-neutral-900) {
+  --tw-bg-opacity: 1;
+  background-color: rgb(23 23 23 / var(--tw-bg-opacity));
+}
 
-  .dark\:hover\:sc-bg-neutral-700\/50:hover {
-    background-color: rgb(64 64 64 / 0.5);
-  }
+:is(.sc-dark .dark\:sc-text-inherit) {
+  color: inherit;
+}
+
+:is(.sc-dark .dark\:sc-text-white) {
+  --tw-text-opacity: 1;
+  color: rgb(255 255 255 / var(--tw-text-opacity));
+}
+
+:is(.sc-dark .dark\:hover\:sc-bg-neutral-700\/50:hover) {
+  background-color: rgb(64 64 64 / 0.5);
 }
 
 @media (min-width: 768px) {

--- a/app/views/layouts/showcase.html.erb
+++ b/app/views/layouts/showcase.html.erb
@@ -4,6 +4,23 @@
     <title>Showcase</title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
 
+    <script>
+      // We're setting this directly here to help prevent Flash of Unstyled Content (FOUC).
+      class Scheme {
+        static start() {
+          const preference = window.matchMedia("(prefers-color-scheme: dark)").matches ? "dark" : "light"
+          this.color = localStorage.colorScheme || preference
+        }
+
+        static set color(value) {
+          localStorage.colorScheme = value
+          document.documentElement.classList.toggle("sc-dark", value === "dark")
+        }
+      }
+
+      Scheme.start()
+    </script>
+
     <%= render "showcase/engine/head" %>
     <%= render "showcase/engine/stylesheets" %>
     <%= render "showcase/engine/javascripts" %>

--- a/app/views/showcase/engine/_root.html.erb
+++ b/app/views/showcase/engine/_root.html.erb
@@ -1,9 +1,16 @@
 <main class="sc-flex sc-flex-wrap dark:sc-bg-neutral-900 dark:sc-text-white" aria-labelledby="showcase_main_title">
   <section class="sc-grid sc-grid-cols-12 sc-w-full">
     <nav class="sc-col-span-3 xl:sc-col-span-2 sc-h-full sc-border-0 sc-border-r sc-border-solid sc-border-gray-200">
-      <h1 id="showcase_main_title" class="sc-font-black sc-text-2xl sc-m-0">
-        <%= link_to "Showcase", root_url, class: "sc-link sc-block sc-pt-5 sc-pb-2 sc-pl-4" %>
-      </h1>
+      <header class="sc-flex sc-items-baseline sc-pt-5 sc-pb-2 sc-pl-4">
+        <h1 id="showcase_main_title" class="sc-font-black sc-text-2xl sc-m-0">
+          <%= link_to "Showcase", root_url, class: "sc-link" %>
+        </h1>
+
+        <section class="sc-link sc-text-sm sc-px-2 sc-cursor-pointer">
+          <a onclick="Scheme.color = 'light'" class="sc-hidden dark:sc-block">light mode</a>
+          <a onclick="Scheme.color = 'dark'" class="sc-block dark:sc-hidden">dark mode</a>
+        </section>
+      </header>
 
       <%= render Showcase::Path.tree %>
     </nav>

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,6 +1,7 @@
 const defaultTheme = require('tailwindcss/defaultTheme')
 
 module.exports = {
+  darkMode: 'class',
   prefix: 'sc-',
   content: [
     './public/*.html',


### PR DESCRIPTION
Also persists to localStorage so users don't have to reclick this continually. If they ever change their color scheme preference, they'll have to click to switch themes, which is less to maintain for us.