### PR TITLE
Test with Rails 7.1

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,7 +13,7 @@ jobs:
       fail-fast: false
       matrix:
         rails-version:
-          - "7.0"
+          - "7.1"
           - "6.1"
           - "main"
         ruby-version:

--- a/test/capybara_extensions/assertions.rb
+++ b/test/capybara_extensions/assertions.rb
@@ -24,6 +24,6 @@ ActiveSupport.on_load :action_view_test_case do
   include CapybaraExtensions::Assertions
 
   def page
-    @page ||= Capybara.string(rendered)
+    @page ||= Capybara.string(rendered.to_s)
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -3,12 +3,12 @@ ENV["RAILS_ENV"] = "test"
 
 require_relative "../test/dummy/config/environment"
 ActiveRecord::Migrator.migrations_paths = [File.expand_path("../test/dummy/db/migrate", __dir__)]
-require "rails/test_help"
-require "capybara_extensions"
-require "template_helpers"
-
 # Don't eager load, since that expects Action Mailbox tables to be present in database.
 Rails.configuration.eager_load = false
+require "rails/test_help"
+
+require "capybara_extensions"
+require "template_helpers"
 
 Showcase.sample_renderer = proc { _1 } if ENV["ROUGE_ENABLED"] == "false"
 

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,9 @@ require "rails/test_help"
 require "capybara_extensions"
 require "template_helpers"
 
+# Don't eager load, since that expects Action Mailbox tables to be present in database.
+Rails.configuration.eager_load = false
+
 Showcase.sample_renderer = proc { _1 } if ENV["ROUGE_ENABLED"] == "false"
 
 # Load fixtures from the engine


### PR DESCRIPTION
We're already compatible with Rails 7.1, our tests just needs a little more tuning.

Probably stemming from `rendered` having been converted to a proxy object in https://github.com/rails/rails/pull/49194