### PR TITLE
Split scrolling for navbar and preview window

### DIFF
--- a/app/assets/builds/showcase.css
+++ b/app/assets/builds/showcase.css
@@ -393,6 +393,10 @@ pre {
   padding-bottom: 0.5rem;
 }
 
+.sc-pb-24 {
+  padding-bottom: 6rem;
+}
+
 .sc-pl-4 {
   padding-left: 1rem;
 }

--- a/app/views/showcase/engine/_root.html.erb
+++ b/app/views/showcase/engine/_root.html.erb
@@ -1,6 +1,6 @@
-<main class="sc-flex sc-flex-wrap dark:sc-bg-neutral-900 dark:sc-text-white" aria-labelledby="showcase_main_title">
+<main class="sc-flex sc-flex-wrap dark:sc-bg-neutral-900 dark:sc-text-white h-screen overflow-hidden" aria-labelledby="showcase_main_title">
   <section class="sc-grid sc-grid-cols-12 sc-w-full">
-    <nav class="sc-col-span-3 xl:sc-col-span-2 sc-h-full sc-border-0 sc-border-r sc-border-solid sc-border-gray-200">
+    <nav class="sc-col-span-3 xl:sc-col-span-2 sc-border-0 sc-border-r sc-border-solid sc-border-gray-200 h-screen overflow-y-auto sc-pb-24">
       <header class="sc-flex sc-items-baseline sc-pt-5 sc-pb-2 sc-pl-4">
         <h1 id="showcase_main_title" class="sc-font-black sc-text-2xl sc-m-0">
           <%= link_to "Showcase", root_url, class: "sc-link" %>
@@ -15,7 +15,7 @@
       <%= render Showcase::Path.tree %>
     </nav>
 
-    <section class="sc-col-span-9 xl:sc-col-span-10 sc-w-full sc-min-h-screen sc-p-12 sc-pt-7">
+    <section class="sc-col-span-9 xl:sc-col-span-10 sc-w-full sc-min-h-screen h-screen overflow-y-auto sc-px-8 sc-pt-5 sc-pb-24">
       <%= yield %>
     </section>
   </section>


### PR DESCRIPTION
Closes #80.

I wanted to use `h-full` or `sc-h-full` for these, but it wasn't working as expected. I saw the fixed footer is rendered in https://github.com/bullet-train-co/bullet_train-core/blob/main/bullet_train-themes-light/app/views/showcase/engine/_head.html.erb, I'm curious if that might have part to do with it. Either way, I think it turned out nice.

https://github.com/bullet-train-co/showcase/assets/10546292/8d067cde-90dc-49b4-bd36-453743e3637b
