### PR TITLE
Make default Rails version 7.X instead of 7.0.X

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,12 +13,11 @@ jobs:
       fail-fast: false
       matrix:
         rails-version:
-          - "7.1"
-          - "6.1"
+          - "7.2"
+          - "8.0"
           - "main"
         ruby-version:
-          - "3.2"
-          - "2.7"
+          - "3.4"
 
     env:
       RAILS_ENV: test

--- a/Gemfile
+++ b/Gemfile
@@ -6,7 +6,7 @@ gemspec
 
 gem "sqlite3"
 
-rails_version = ENV.fetch("RAILS_VERSION", "7.0")
+rails_version = ENV.fetch("RAILS_VERSION", "7")
 
 rails_constraint = if rails_version == "main"
   {github: "rails/rails"}

--- a/app/assets/builds/showcase.highlights.css
+++ b/app/assets/builds/showcase.highlights.css
@@ -39,6 +39,10 @@
   color: #116329;
   background-color: #dafbe1;
 }
+.sc-highlight .ges {
+  font-weight: bold;
+  font-style: italic;
+}
 .sc-highlight .kc {
   color: #0550ae;
 }
@@ -152,6 +156,10 @@
   .sc-highlight .gi {
     color: #aff5b4;
     background-color: #033a16;
+  }
+  .sc-highlight .ges {
+    font-weight: bold;
+    font-style: italic;
   }
   .sc-highlight .kc {
     color: #79c0ff;

--- a/showcase.gemspec
+++ b/showcase.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |spec|
     Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
   end
 
-  spec.add_dependency "rails", ">= 6.1.0"
+  spec.add_dependency "rails", ">= 7.2"
   spec.add_development_dependency "tailwindcss-rails"
 end


### PR DESCRIPTION
When trying to launch the Rails server with the Rails version set to the latest 7.0.X, it fails with the following error message:

```txt
uninitialized constant ActiveSupport::LoggerThreadSafeLevel::Logger (NameError)
```

The [issue](https://github.com/rails/rails/issues/54271) has been solved in Rails version 7.1.X, and so we should stop using the 7.0.X version as the default in development mode for the showcase engine.

I also dropped support for Rails 6.X and Ruby 2.X as they are not maintained anymore.